### PR TITLE
build: generate static build and serve with caddy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,20 +39,12 @@ ENV NODE_ENV=production
 RUN pnpm run build
 
 # serve
-FROM node:20-alpine AS serve
+FROM caddy:2-alpine AS serve
 
-RUN mkdir /app && chown -R node:node /app
-WORKDIR /app
+WORKDIR /usr/share/caddy
 
-USER node
-
-COPY --from=build --chown=node:node /app/dist ./dist
-
-ENV NODE_ENV=production
-
-ENV HOST=0.0.0.0
-ENV PORT=3000
+COPY --from=build /app/dist /usr/share/caddy
 
 EXPOSE 3000
 
-CMD [ "node", "./dist/server/entry.mjs" ]
+CMD ["caddy", "file-server", "--listen", ":3000"]

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,5 +1,5 @@
 // import mdx from "@astrojs/mdx";
-import node from "@astrojs/node";
+// import node from "@astrojs/node";
 // import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 // import keystatic from "@keystatic/astro";
@@ -10,9 +10,9 @@ import { loadEnv } from "vite";
 const env = loadEnv(import.meta.env.MODE, process.cwd(), "");
 
 export default defineConfig({
-	adapter: node({
-		mode: "standalone",
-	}),
+	// adapter: node({
+	// 	mode: "standalone",
+	// }),
 	base: env.PUBLIC_APP_BASE_PATH,
 	integrations: [
 		icon({
@@ -39,7 +39,7 @@ export default defineConfig({
 		// react(),
 		sitemap(),
 	],
-	output: "hybrid",
+	// output: "hybrid",
 	prefetch: {
 		defaultStrategy: "hover",
 		prefetchAll: true,


### PR DESCRIPTION
this generates a static build (instead of Astro's "hybrid" output served by node), and uses caddy as simple file server.